### PR TITLE
Include LTV in per-customer API response

### DIFF
--- a/app.py
+++ b/app.py
@@ -266,7 +266,7 @@ def process_rfm():
         rfm_df.to_csv(output_file, index=False)
 
         return jsonify({
-            "data": rfm_df[["CustomerID", "Cluster", "Cluster Meaning", "Likely_Churn"]].to_dict(orient="records"),
+            "data": rfm_df[["CustomerID", "Cluster", "Cluster Meaning", "Likely_Churn", "LTV"]].to_dict(orient="records"),
             "download_link": "/download_csv"
         })
 


### PR DESCRIPTION
## Summary
- include the LTV metric in the per-customer data returned by the RFM processing endpoint
- keep the generated CSV aligned with the enriched data payload

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_69015e472300833083452d4d88ef8c6b